### PR TITLE
解决调度时，会选择到dead worker的问题

### DIFF
--- a/pkg/cdule/schedule_watcher.go
+++ b/pkg/cdule/schedule_watcher.go
@@ -56,7 +56,7 @@ func runNextScheduleJobs(scheduleStart, scheduleEnd int64) {
 		log.Error(err)
 		return
 	}
-	workers, err := model.CduleRepos.CduleRepository.GetWorkers()
+	workers, err := model.CduleRepos.CduleRepository.GetAliveWorkers()
 	if nil != err {
 		log.Error(err)
 		return

--- a/pkg/model/cdule_repository.go
+++ b/pkg/model/cdule_repository.go
@@ -13,10 +13,10 @@ type cduleRepository struct {
 }
 
 // NewCduleRepository cdule repository
-func NewCduleRepository(db *gorm.DB, heart time.Duration) CduleRepository {
+func NewCduleRepository(db *gorm.DB) CduleRepository {
 	return cduleRepository{
 		DB:    db,
-		Heart: heart,
+		Heart: 30 * time.Second,
 	}
 }
 

--- a/pkg/model/cdule_repository.go
+++ b/pkg/model/cdule_repository.go
@@ -26,6 +26,7 @@ type CduleRepository interface {
 	UpdateWorker(worker *Worker) (*Worker, error)
 	GetWorker(workerID string) (*Worker, error)
 	GetWorkers() ([]Worker, error)
+	GetAliveWorkers() ([]Worker, error)
 	DeleteWorker(workerID string) (*Worker, error)
 
 	CreateJob(job *Job) (*Job, error)

--- a/pkg/model/cdule_repository.go
+++ b/pkg/model/cdule_repository.go
@@ -2,18 +2,21 @@ package model
 
 import (
 	"gorm.io/gorm"
+	"time"
 
 	"github.com/deepaksinghvi/cdule/pkg"
 )
 
 type cduleRepository struct {
-	DB *gorm.DB
+	DB    *gorm.DB
+	Heart time.Duration
 }
 
 // NewCduleRepository cdule repository
-func NewCduleRepository(db *gorm.DB) CduleRepository {
+func NewCduleRepository(db *gorm.DB, heart time.Duration) CduleRepository {
 	return cduleRepository{
-		DB: db,
+		DB:    db,
+		Heart: heart,
 	}
 }
 
@@ -80,6 +83,17 @@ func (c cduleRepository) GetWorker(workerID string) (*Worker, error) {
 func (c cduleRepository) GetWorkers() ([]Worker, error) {
 	var workers []Worker
 	if err := c.DB.Find(&workers).Error; err != nil {
+		return workers, err
+	}
+	return workers, nil
+}
+
+// GetAliveWorkers to get a list of alive workers
+func (c cduleRepository) GetAliveWorkers() ([]Worker, error) {
+	var workers []Worker
+	// updated_at gt 3 heart means alive
+	available := time.Now().Add(-3 * c.Heart)
+	if err := c.DB.Where("updated_at > ?", available).Find(&workers).Error; err != nil {
 		return workers, err
 	}
 	return workers, nil


### PR DESCRIPTION
repository增加方法：GetAliveWorkers 获取存活的worker
schduler_watcher 调度时，使用该方法获取存活的worker